### PR TITLE
메뉴 클래스 Parcelize 어노테이션 대신 Parcelable 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
-    id("kotlin-parcelize")
 }
 
 android {

--- a/app/src/main/java/com/harmony6/harmony_cafe/data/Menu.kt
+++ b/app/src/main/java/com/harmony6/harmony_cafe/data/Menu.kt
@@ -1,16 +1,72 @@
 package com.harmony6.harmony_cafe.data
 
+import android.os.Parcel
 import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
 import java.time.LocalDate
 
-@Parcelize
-data class Components(val name: String, val desc: String, val img: Int) : Parcelable
+data class Components(val name: String, val desc: String, val img: Int) : Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readString().toString(),
+        parcel.readString().toString(),
+        parcel.readInt()
+    )
 
-@Parcelize
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(name)
+        parcel.writeString(desc)
+        parcel.writeInt(img)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<Components> {
+        override fun createFromParcel(parcel: Parcel): Components {
+            return Components(parcel)
+        }
+
+        override fun newArray(size: Int): Array<Components?> {
+            return arrayOfNulls(size)
+        }
+    }
+}
+
 data class Menu(
     val name: String, val desc: String, val img: Int,
     val username: String,
     val createdDate: LocalDate,
     val components: List<Components> = listOf()
-) : Parcelable
+) : Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readString().toString(),
+        parcel.readString().toString(),
+        parcel.readInt(),
+        parcel.readString().toString(),
+        parcel.readValue(LocalDate::class.java.classLoader) as LocalDate,
+        parcel.createTypedArrayList(Components.CREATOR) ?: listOf()
+    )
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(name)
+        parcel.writeString(desc)
+        parcel.writeInt(img)
+        parcel.writeString(username)
+        parcel.writeValue(createdDate)
+        parcel.writeTypedList(components)
+    }
+
+    companion object CREATOR : Parcelable.Creator<Menu> {
+        override fun createFromParcel(parcel: Parcel): Menu {
+            return Menu(parcel)
+        }
+
+        override fun newArray(size: Int): Array<Menu?> {
+            return arrayOfNulls(size)
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 어노테이션 삭제 (`build.grade` 수정)
- 클래스 내부에 Parcelable 구현체 추가